### PR TITLE
Rewrite MCP server using OSP

### DIFF
--- a/mcp_server.jac
+++ b/mcp_server.jac
@@ -1,40 +1,46 @@
 import sys;
 import os;
-import from rag {RagEngine, WebSearch}
-import from mcp.server.fastmcp.tools {Tool}
-import from mcp.server.fastmcp {FastMCP}
 import typing;
+import from rag {RagEngine, WebSearch};
+import from mcp.server.fastmcp {FastMCP};
 
-glob rag_engine: RagEngine = RagEngine();
-glob web_search: WebSearch = WebSearch();
-
-
-with entry {
-    mcp = FastMCP(name="RAG-MCP", port=8899);
-}
+# Helper to ensure Python type hints are preserved
 
 def resolve_hints(fn: typing.Callable) -> typing.Callable {
     fn.__annotations__ = typing.get_type_hints(fn, include_extras=True);
     return fn;
 }
 
-@mcp.tool(name="search_docs")
-@resolve_hints 
-async def tool_search_docs(query: str) -> str {
-    return rag_engine.search(query);
-}
+obj MCPServer {
+    has rag_engine: RagEngine = RagEngine();
+    has web_search: WebSearch = WebSearch();
+    has mcp: FastMCP;
 
-@mcp.tool(name="search_web")
-@resolve_hints 
-async def tool_search_web(query: str) -> str{
-    web_search_results = web_search.search(query);
-    if not web_search_results {
-        return "Mention No results found for the web search";
+    def postinit {
+        self.mcp = FastMCP(name="RAG-MCP", port=8899);
+        # register tools on initialization
+        self.mcp.tool(name="search_docs")(resolve_hints(self.tool_search_docs));
+        self.mcp.tool(name="search_web")(resolve_hints(self.tool_search_web));
     }
-    return web_search_results;
-}
 
+    async def tool_search_docs(query: str) -> str {
+        return self.rag_engine.search(query);
+    }
+
+    async def tool_search_web(query: str) -> str {
+        web_search_results = self.web_search.search(query);
+        if not web_search_results {
+            return "Mention No results found for the web search";
+        }
+        return web_search_results;
+    }
+
+    def start_server {
+        self.mcp.run("streamable-http");
+    }
+}
 
 with entry {
-    mcp.run("streamable-http");
+    server = MCPServer();
+    server.start_server();
 }


### PR DESCRIPTION
## Summary
- reimplement `mcp_server.jac` using Object Spatial Programming
- use a new `MCPServer` object that registers tools on init
- start the MCP server from the entrypoint

## Testing
- `pytest`
- `pyright`
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_686ccf169ce083239e0e75616e8f06ea