### PR TITLE
Refactor multimodal support

### DIFF
--- a/current copy/server.jac
+++ b/current copy/server.jac
@@ -21,21 +21,17 @@ glob MCP_SERVER_URL: str = os.getenv('MCP_SERVER_URL', 'http://localhost:8899/mc
 
 
 """ChatType enum defines the types of chat interactions. ChatType must be one of:
-- RAG: For interactions that require document retrieval.
+- RAG: For interactions that require document retrieval or multimodal reasoning.
 - QA: For interactions that can be answered directly without document retrieval.
-- IMAGE: For interactions involving image analysis.
-- VIDEO: For interactions involving video analysis.
 """
 enum ChatType {
     RAG = "RAG",
-    QA = "QA",
-    IMAGE = "IMAGE",
-    VIDEO = "VIDEO"
+    QA = "QA"
 }
 
 
 node Router {
-    "Classify the message as RAG, QA, IMAGE, or VIDEO. If classification fails, default to QA."
+    "Classify the message as RAG or QA. If classification fails, default to QA."
     def classify(message: str) -> ChatType by llm(method="Reason", temperature=0.8);
 }
 
@@ -69,8 +65,6 @@ walker infer {
             router_node = here ++> Router();
             router_node ++> RagChat();
             router_node ++> QAChat();
-            router_node ++> ImageChat();
-            router_node ++> VideoChat();
             visit router_node;
         }
     }
@@ -82,90 +76,6 @@ walker infer {
 }
 
 
-node ImageChat(Chat) {
-    has chat_type: ChatType = ChatType.IMAGE_CHAT;
-
-    """Generate a helpful response to the user's message. Use available mcp tool when needed.Use list_mcp_tools to find out what are the available tools. Always pass arguments as a flat dictionary (e.g., {\"query\": \"Your search query\"}), never as a list or schema_dict_wrapper. """ 
-    def respond(message:str, chat_history:list[dict]) -> str by llm(
-            method="ReAct",
-            tools=([list_mcp_tools, use_mcp_tool]),
-            messages=chat_history,
-            max_react_iterations=6
-        );
-    can chat with infer entry {
-        logger.info("interact walker has entered to Imagechat node: %s", visitor.message);
-        response = self.respond(
-            message=visitor.message,
-            chat_history=visitor.chat_history,
-        );
-        logger.info("Response generated at RAG: %s", response);
-        visitor.chat_history.append({"role": "assistant", "content": response});
-        self.chat_history = visitor.chat_history;
-        visitor.response = response;
-        report {"response": response, "chat_history": visitor.chat_history};
-    }
-}
-
-# node ImageChat(Chat) {
-#     has chat_type: ChatType = ChatType.IMAGE;
-
-#     """Generate a helpful response to the user's message. Use available mcp tool when needed.Use list_mcp_tools to find out what are the available tools. Always pass arguments as a flat dictionary (e.g., {\"query\": \"Your search query\"}), never as a list or schema_dict_wrapper. """ 
-#     def respond(message: str) -> str by llm(
-#             method="ReAct",
-#             tools=([use_mcp_tool, list_mcp_tools]),
-#             # messages=chat_history,
-#             max_react_iterations=6
-#         );
-
-#     """Generate a response to the user's message using an image and text."""
-#     def respond_with_image(img: Image, text: Text) -> str by llm(
-#         method="Chain-of-Thoughts",
-#     );
-
-#     with entry {
-#         logger.info("ImageChat node initialized with chat type: IMAGE");
-#     }
-
-#     can chat with infer entry {
-#         logger.info("interact walker has entered to Imagechat node: %s", visitor.message);
-#         img = Image("uploads/user_session_123/photo.jpg");
-#         # response = self.respond_with_image(
-#         #     img=img,
-#         #     text="Describe the image content."
-#         # );
-#         response = "Image looks great!";
-#         visitor.chat_history.append({"role": "assistant", "content": response});
-#         self.chat_history = visitor.chat_history;
-#         visitor.response = response;
-#         print("Response generated:", response);
-#         report {"response": response, "chat_history": visitor.chat_history};
-#     }
-# }
-
-
-
-node VideoChat(Chat) {
-    has chat_type: ChatType = ChatType.VIDEO;
-
-    "Respond to message using video analysis (VIDEO)"
-    def respond(message: str, chat_history: list[dict]) -> str by llm(
-            method="ReAct",
-            tools=([list_mcp_tools, use_mcp_tool]),
-            max_react_iterations=6
-        );
-    }
-    can chat with infer entry {
-        # Sync walker chat_history with node chat_histor
-        print("interact walker has entered to Videochat node", visitor.message);
-        response = self.respond(
-            message=visitor.message,
-            chat_history=visitor.chat_history,
-        );
-        visitor.chat_history.append({"role": "assistant", "content": response});
-        self.chat_history = visitor.chat_history;
-        visitor.response = response;
-        report {"response": response, "chat_history": visitor.chat_history};
-}
 
 node RagChat(Chat) {
     has chat_type: ChatType = ChatType.RAG;
@@ -176,6 +86,16 @@ node RagChat(Chat) {
             tools=([list_mcp_tools, use_mcp_tool]),
             messages=chat_history,
             max_react_iterations=6
+        );
+
+    """Generate a response to the user's message using an image and text."""
+    def respond_with_image(img: Image, text: Text) -> str by llm(
+            method="Chain-of-Thoughts"
+        );
+
+    """Generate a response to the user's message using a video and text."""
+    def respond_with_video(video: Video, text: Text) -> str by llm(
+            method="Chain-of-Thoughts"
         );
     can chat with infer entry {
         logger.info("interact walker has entered to Ragchat node: %s", visitor.message);


### PR DESCRIPTION
## Summary
- keep only QA and RAG chat nodes
- add basic image and video methods to `RagChat`

## Testing
- `jac check 'current copy/server.jac'`

------
https://chatgpt.com/codex/tasks/task_e_687f332e0b3083238b839fe97e64c01b